### PR TITLE
Connection manager

### DIFF
--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { AdminKeyBoardShortcut } from "@/components/admin-shortcut";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { CardanoProvider } from "@/context/cardano";
+import { WalletConnectionProvider } from "@/context/wallet-connection-manager";
 const plusJakartaSans = Plus_Jakarta_Sans({
   variable: "--font-plus-jakarta-sans",
   subsets: ["vietnamese"],
@@ -38,8 +39,10 @@ export default async function RootLayout({
           <TanstackProvider>
             <CardanoProvider>
               <AppKitProvider cookies={cookies}>
-                <Navbar />
-                {children}
+                <WalletConnectionProvider>
+                  <Navbar />
+                  {children}
+                </WalletConnectionProvider>
                 <AdminKeyBoardShortcut />
                 <Analytics />
                 <SpeedInsights />

--- a/site/src/components/appkit-wallet-button.tsx
+++ b/site/src/components/appkit-wallet-button.tsx
@@ -2,20 +2,19 @@
 import {
   useDisconnect,
   useAppKit,
-  // useAppKitNetwork,
   useAppKitAccount,
 } from "@reown/appkit/react";
 import { Button } from "./ui/button";
-// import { networks } from "@/config";
 import { toast } from "sonner";
 import { IconWallet } from "@tabler/icons-react";
 import { useEffect, useRef } from "react";
+import { useWalletConnection } from "@/context/wallet-connection-manager";
 
 export const WalletButton = () => {
   const { disconnect } = useDisconnect();
   const { open } = useAppKit();
-  // const { switchNetwork } = useAppKitNetwork();
   const { isConnected } = useAppKitAccount();
+  const { isConnectionAllowed } = useWalletConnection();
   const prevConnectedRef = useRef(false);
 
   // Effect to detect when connection state changes from false to true
@@ -27,6 +26,11 @@ export const WalletButton = () => {
   }, [isConnected]);
 
   const handleConnect = () => {
+    // Check if this connection attempt is allowed
+    if (!isConnectionAllowed("avalanche")) {
+      return;
+    }
+
     open();
   };
 

--- a/site/src/components/custom-cardano-wallet.tsx
+++ b/site/src/components/custom-cardano-wallet.tsx
@@ -22,7 +22,7 @@ import { Wallet, CheckCircle2, Loader2, AlertCircle } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
-
+import { useWalletConnection } from "@/context/wallet-connection-manager";
 export const CustomCardanoWallet = () => {
   const [open, setOpen] = useState(false);
   const [connectingWalletId, setConnectingWalletId] = useState<string | null>(
@@ -55,7 +55,7 @@ export const CustomCardanoWallet = () => {
     error: walletError,
     name: connectedWalletName,
   } = useWallet();
-
+  const { isConnectionAllowed } = useWalletConnection();
   const prevConnectedRef = useRef(false);
 
   // detects available wallets
@@ -139,6 +139,11 @@ export const CustomCardanoWallet = () => {
   }, [walletError]);
 
   const handleConnect = async (walletId: string) => {
+    // check if connection should even be allowed
+    if (!isConnectionAllowed("cardano")) {
+      return;
+    }
+
     try {
       setConnectingWalletId(walletId);
       setIsConnecting(true);

--- a/site/src/components/navbar.tsx
+++ b/site/src/components/navbar.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useRouter } from "next/navigation";
 import { CustomCardanoWallet } from "./custom-cardano-wallet";
+import { WalletStatus } from "./wallet-status";
 export function Navbar() {
   const pathname = usePathname();
   const isHomePage = pathname === "/";
@@ -29,6 +30,7 @@ export function Navbar() {
         <div className="flex items-center gap-4">
           <CustomCardanoWallet />
           <WalletButton />
+          <WalletStatus />
         </div>
       </div>
     </header>

--- a/site/src/components/wallet-status.tsx
+++ b/site/src/components/wallet-status.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useWalletConnection } from "@/context/wallet-connection-manager";
+import { useWallet as useCardanoWallet } from "@meshsdk/react";
+import { useAppKitAccount } from "@reown/appkit/react";
+import { Badge } from "./ui/badge";
+
+export const WalletStatus = () => {
+  const { connected: isCardanoConnected, name: cardanoWalletName } =
+    useCardanoWallet();
+  const { isConnected: isAvalancheConnected, address: avalancheAddress } =
+    useAppKitAccount();
+
+  // Get short address format for display
+  const shortAddress = (address?: string) => {
+    if (!address) return "";
+    return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`;
+  };
+
+  if (!isCardanoConnected && !isAvalancheConnected) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center space-x-2">
+      {isCardanoConnected && (
+        <Badge
+          variant="outline"
+          className="bg-amber-50 text-amber-700 border-amber-200"
+        >
+          Cardano: {cardanoWalletName || "Connected"}
+        </Badge>
+      )}
+
+      {isAvalancheConnected && (
+        <Badge
+          variant="outline"
+          className="bg-blue-50 text-blue-700 border-blue-200"
+        >
+          Avalanche: {shortAddress(avalancheAddress)}
+        </Badge>
+      )}
+    </div>
+  );
+};

--- a/site/src/context/wallet-connection-manager.tsx
+++ b/site/src/context/wallet-connection-manager.tsx
@@ -1,0 +1,82 @@
+"use client";
+import React, { createContext, useState, useEffect, useContext } from "react";
+import { useWallet as useCardanoWallet } from "@meshsdk/react";
+import { useAppKitAccount } from "@reown/appkit/react";
+import { toast } from "sonner";
+export type WalletType = "avalanche" | "cardano" | null;
+interface WalletConnection {
+  activeWallet: WalletType;
+  isConnectionAllowed: (type: WalletType) => boolean;
+  isWalletConnected: boolean;
+}
+
+export const WalletConnectionContext = createContext<WalletConnection>({
+  activeWallet: null,
+  isConnectionAllowed: () => false,
+  isWalletConnected: false,
+});
+// hook for using the wallet connection context
+export const useWalletConnection = () => useContext(WalletConnectionContext);
+export const WalletConnectionProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [activeWallet, setActiveWallet] = useState<WalletType>(null);
+
+  const { connected: isCardanoConnected } = useCardanoWallet();
+  const { isConnected: isAvalancheConnected } = useAppKitAccount();
+  useEffect(() => {
+    if (isCardanoConnected && !isAvalancheConnected) {
+      setActiveWallet("cardano");
+      console.log("...cardano wallet is active");
+    } else if (isAvalancheConnected && !isCardanoConnected) {
+      setActiveWallet("avalanche");
+      console.log("...avalanche wallet is active");
+    } else if (isCardanoConnected && isAvalancheConnected) {
+      // technically this state shouldn't be possible this is just a monitor for unexpected states
+      console.warn(
+        "FATAL ERROR: BOTH WALLETS ARE CONNECTED AT THE SAME TIME , THIS SHOULD NOT BE POSSIBLE!",
+      );
+    } else {
+      // neither are connected
+      setActiveWallet(null);
+    }
+  }, [isAvalancheConnected, isCardanoConnected]);
+  // this just checks whether a connection should be allowed
+  const isConnectionAllowed = (type: WalletType): boolean => {
+    if (!type) return false;
+
+    // if same wallet type is already active, do nothing
+    if (activeWallet === type) return true;
+
+    try {
+      // if another wallet is connected, show warning
+      if (activeWallet) {
+        toast.warning(
+          `Please disconnect your ${activeWallet} wallet before connecting to ${type}`,
+        );
+        return false;
+      }
+
+      // at this point, no wallet is connected, so the user is free to connect
+      return true;
+    } catch (error) {
+      console.error(`Error checking wallet connection status:`, error);
+      return false;
+    }
+  };
+
+  const isWalletConnected = isCardanoConnected || isAvalancheConnected;
+  return (
+    <WalletConnectionContext.Provider
+      value={{
+        activeWallet,
+        isWalletConnected,
+        isConnectionAllowed,
+      }}
+    >
+      {children}
+    </WalletConnectionContext.Provider>
+  );
+};


### PR DESCRIPTION
This pull request introduces a wallet connection management system to handle multi-wallet support and ensure users can only connect one wallet type at a time. The main changes include adding a `WalletConnectionProvider` context, updating components to use the new context, and introducing a `WalletStatus` component to display wallet connection statuses.

### Wallet Connection Management:

* **New `WalletConnectionProvider` context**: Added a context in `site/src/context/wallet-connection-manager.tsx` to manage wallet connection states, enforce single-wallet connections, and provide utility methods like `isConnectionAllowed`.
* **Integration into `RootLayout`**: Wrapped the application with the `WalletConnectionProvider` in `site/src/app/layout.tsx` to make the context available globally. [[1]](diffhunk://#diff-c87e46d0a581702f2155b7db694598820683c0135a75d5f6e5cbb6235051ab81R15) [[2]](diffhunk://#diff-c87e46d0a581702f2155b7db694598820683c0135a75d5f6e5cbb6235051ab81R42-R45)

### Component Updates for Wallet Connection:

* **`WalletButton`**: Updated `site/src/components/appkit-wallet-button.tsx` to use `isConnectionAllowed` from the new context, preventing connection attempts when another wallet is already connected. [[1]](diffhunk://#diff-afcfcc86b3ce1248631353c0b56f4db00d08bc1eaab00a85df0f070e066c689eL5-R17) [[2]](diffhunk://#diff-afcfcc86b3ce1248631353c0b56f4db00d08bc1eaab00a85df0f070e066c689eR29-R33)
* **`CustomCardanoWallet`**: Updated `site/src/components/custom-cardano-wallet.tsx` to use `isConnectionAllowed` for similar connection restrictions. [[1]](diffhunk://#diff-7f74f116251e4ed5c22c5b1a1ae6f5ce1f6dd27a39bb2c1d4f5fb9f4b97bfdf8L25-R25) [[2]](diffhunk://#diff-7f74f116251e4ed5c22c5b1a1ae6f5ce1f6dd27a39bb2c1d4f5fb9f4b97bfdf8L58-R58) [[3]](diffhunk://#diff-7f74f116251e4ed5c22c5b1a1ae6f5ce1f6dd27a39bb2c1d4f5fb9f4b97bfdf8R142-R146)

### New Wallet Status Display:

* **`WalletStatus` Component**: Introduced a new `WalletStatus` component in `site/src/components/wallet-status.tsx` to display the connection status of Cardano and Avalanche wallets. Integrated it into the `Navbar` component. [[1]](diffhunk://#diff-68e5489ecc913bfdbf345c35f47e1857904ecb2df0e7faedc7680695277ff636R1-R45) [[2]](diffhunk://#diff-ea0fda570a74f9ac7a018c5392b796054c7f28ea23cca1dad9ed962dbbe54fefR7) [[3]](diffhunk://#diff-ea0fda570a74f9ac7a018c5392b796054c7f28ea23cca1dad9ed962dbbe54fefR33)