### PR TITLE
fix: cardano wallet connection is now persistent

### DIFF
--- a/site/src/components/wallet-popover.tsx
+++ b/site/src/components/wallet-popover.tsx
@@ -22,10 +22,11 @@ import { WalletButton } from "./appkit-wallet-button";
 import { CustomCardanoWallet } from "./custom-cardano-wallet";
 import { Separator } from "./ui/separator";
 import { toast } from "sonner";
+import { useEffect } from "react";
 import { useWalletConnection } from "@/context/wallet-connection-manager";
 export const WalletPopover = () => {
   const [open, setOpen] = useState(false);
-  const { name: cardanoWalletName } = useCardanoWallet();
+  const { name: cardanoWalletName, connect, connected } = useCardanoWallet();
   const { address: avalancheAddress } = useAppKitAccount();
   const { activeWallet, isWalletConnected } = useWalletConnection();
 
@@ -47,6 +48,18 @@ export const WalletPopover = () => {
     if (activeWallet === "avalanche") return "Avalanche";
     return "Wallet";
   };
+  //TODO: CLEAN THIS UP
+  useEffect(() => {
+    const last = window.localStorage.getItem("mesh-wallet-persist");
+    if (last && !connected) {
+      const content = JSON.parse(last);
+      //reconnect and keep it persisted:
+      connect(content.walletName, true).catch(() => {
+        /* maybe wallet was removed, clear storage */
+        window.localStorage.removeItem("mesh-wallet-persist");
+      });
+    }
+  }, [connected, connect]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
This pull request updates the `WalletPopover` component in `site/src/components/wallet-popover.tsx` to improve wallet reconnection functionality and enhance state management. The most important changes include adding a `useEffect` hook to handle wallet reconnection using persisted data and extending the `useCardanoWallet` hook to include `connect` and `connected` properties.

### Wallet reconnection improvements:

* Added a `useEffect` hook to automatically reconnect to the last used wallet if it was persisted in local storage. If the wallet is no longer available, the persisted data is cleared to avoid errors. (`[site/src/components/wallet-popover.tsxR51-R62](diffhunk://#diff-2a6870b0f5dfcdbffdcb9717a48dc0b2878a41ba657cd9ad90504e7f7db63d9cR51-R62)`)

### State management enhancements:

* Updated the `useCardanoWallet` hook to include `connect` and `connected` properties, enabling wallet connection logic to be managed directly within the component. (`[site/src/components/wallet-popover.tsxR25-R29](diffhunk://#diff-2a6870b0f5dfcdbffdcb9717a48dc0b2878a41ba657cd9ad90504e7f7db63d9cR25-R29)`)